### PR TITLE
Remove unneeded CSS classes

### DIFF
--- a/src/Components/Symbol/symbols.css
+++ b/src/Components/Symbol/symbols.css
@@ -1,18 +1,3 @@
-.animate-x-big-symbol {
-    animation-duration: 0.75s;
-    animation-name: add-icon-big-x;
-}
-
-.animate-o-big-symbol {
-    animation-duration: 0.75s;
-    animation-name: add-icon-big-o;
-}
-
-.animate-no-winner-big-symbol {
-    animation-duration: 0.75s;
-    animation-name: add-icon-big-no-winner;
-}
-
 .animate-o, .animate-x {
     animation-duration: 0.75s;
     animation-name: add-icon;


### PR DESCRIPTION
You don't need these CSS classes in your symbols.css file. That's why I removed 'em.